### PR TITLE
Unicode error fix

### DIFF
--- a/tovian/gui/components/annotation.py
+++ b/tovian/gui/components/annotation.py
@@ -369,7 +369,6 @@ class Annotation(QObject):
             self.edited_graphics_object.NOT_ACTIVE_COLOR = graphics_object.not_active_color
             self.edited_graphics_object.setPen(graphics_object.pen())
             self.edited_graphics_object.setFontSize(self.label_font_size)
-            print labels[0], labels[1]
             self.edited_graphics_object.setLabels(labels[0], labels[1])
             self.edited_graphics_object.setPos(graphics_object.pos())
             self.edited_graphics_object.resize(graphics_object.width, graphics_object.height)

--- a/tovian_cli.py
+++ b/tovian_cli.py
@@ -518,6 +518,7 @@ def action_update(args, root_dir):
 
 if __name__ == "__main__":
     root_dir = os.path.dirname(os.path.realpath(sys.argv[0]))
+    # root_dir = unicode(root_dir, sys.getfilesystemencoding())
 
     all_exportable_entities = ['Annotator', 'Video', 'AnnotationAttribute', 'AnnotationObject', 'AnnotationValue']
     actions_using_database = ['init_db', 'load_fixtures', 'db_benchmark', 'export', 'import', 'add', 'init_default_data']

--- a/tovian_cli.py
+++ b/tovian_cli.py
@@ -518,7 +518,7 @@ def action_update(args, root_dir):
 
 if __name__ == "__main__":
     root_dir = os.path.dirname(os.path.realpath(sys.argv[0]))
-    # root_dir = unicode(root_dir, sys.getfilesystemencoding())
+    root_dir = unicode(root_dir, sys.getfilesystemencoding())
 
     all_exportable_entities = ['Annotator', 'Video', 'AnnotationAttribute', 'AnnotationObject', 'AnnotationValue']
     actions_using_database = ['init_db', 'load_fixtures', 'db_benchmark', 'export', 'import', 'add', 'init_default_data']

--- a/tovian_gui.py
+++ b/tovian_gui.py
@@ -95,6 +95,7 @@ def check_requirements():
 def start(environment='production'):
     # initialize logging before anything else
     root_dir = os.path.dirname(os.path.realpath(sys.argv[0]))
+    # root_dir = unicode(root_dir, sys.getfilesystemencoding())
     log_dir = os.path.join(root_dir, 'log')
 
     if not os.path.isdir(log_dir):

--- a/tovian_gui.py
+++ b/tovian_gui.py
@@ -95,7 +95,7 @@ def check_requirements():
 def start(environment='production'):
     # initialize logging before anything else
     root_dir = os.path.dirname(os.path.realpath(sys.argv[0]))
-    # root_dir = unicode(root_dir, sys.getfilesystemencoding())
+    root_dir = unicode(root_dir, sys.getfilesystemencoding())
     log_dir = os.path.join(root_dir, 'log')
 
     if not os.path.isdir(log_dir):


### PR DESCRIPTION
Fixed Unicode decode error when application is launched from patch which contains non-ascii chars:
e.g. /home/milan/Programování/Tovian_git

Error affects both Windows and Linux.
